### PR TITLE
support parsing files that use a space instead of a backtick on end

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -139,6 +139,16 @@ describe('UUE file finder and decoder', function(){
          null
       );
    });
+
+   it("decodes file with space instead of backtick before end", function(){
+      assert.strictEqual(
+         UUE.decodeFile(
+            'begin 644 buffer.bin\n \nend',
+            'buffer.bin'
+         ).toString('binary'),
+         Buffer(0).toString('binary')
+      );
+   });
 });
 
 describe('multiple UUE file finder and decoder', function(){

--- a/uue.js
+++ b/uue.js
@@ -162,7 +162,7 @@ UUE.prototype.decodeFile = function(text, filename){
          '(',
          '(?:[\x20-\x60]+\n)*', // allow garbage after significant characters
          ')',
-         '`\n',
+         '(?:`| )\n',
          'end$'
       ].join(''),
       'gm'
@@ -252,7 +252,7 @@ UUE.prototype.decodeAllFiles = function(text){
          '(',
          '(?:[\x20-\x60]+\n)*', // allow garbage after significant characters
          ')',
-         '`\n',
+         '(?:`| )\n',
          'end$'
       ].join(''),
       'gm'
@@ -349,7 +349,7 @@ UUE.prototype.split = function(text){
          '(',
          '^begin [0-7]{3} \\S+?\n',
          '(?:[\x20-\x60]+\n)*', // allow garbage after significant characters
-         '`\n',
+         '(?:`| )\n',
          'end$',
          ')'
       ].join(''),


### PR DESCRIPTION
This supports a less strict parsing of uuencoded files, ones that have a space instead of a backtick on the line before the end. This fixes parsing for a file found in the wild that we need to handle.

I know this isn't part of the spec and I would normally be against this change, but all other decoding parsers I tried handled this, so I think node-uue should as well.