### PR TITLE
Escape special characters

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -188,6 +188,18 @@ describe('UUE file finder and decoder', function(){
          Buffer('Cats', 'ascii').toString('binary')
       );
    });
+
+   it('decodes it if filename contains special RegEx characters',
+   function(){
+     assert.strictEqual(
+         UUE.decodeFile(
+            'foo bar \n' +
+            'begin 644 FURRYCAT(S.xml\n#0V%T\n \nend\n',
+            'FURRYCAT(S.xml'
+         ).toString('binary'),
+         Buffer('Cat', 'ascii').toString('binary')
+     );
+   });
 });
 
 describe('multiple UUE file finder and decoder', function(){

--- a/uue.js
+++ b/uue.js
@@ -155,9 +155,11 @@ UUE.prototype.encode = function(encodeSource, encodeOptions){
 
 UUE.prototype.decodeFile = function(text, filename){
    var matches = [];
+   var escapedFilename = filename
+     .replace(/([.*+?=^!:${}()|[\]\/\\])/g, '\\$1');
    var potentialUUE = RegExp(
       [
-         '^begin [0-7]{3} ' + filename + '\n',
+         '^begin [0-7]{3} ' + escapedFilename + '\n',
          '(',
          '(?:[\x20-\x60]+\n)*', // allow garbage after significant characters
          ')',


### PR DESCRIPTION
Resolves issue #3

The problem: If a filename contains any of the RegEx special characters, this library throws an exception.

Solution: We would like the library to handle filenames with special RegEx characters properly, so we propose escaping them