### PR TITLE
Fix relying on buffer overflow

### DIFF
--- a/uue.js
+++ b/uue.js
@@ -222,14 +222,18 @@ UUE.prototype.decodeFile = function(text, filename){
             total +=  (lineUUE.charCodeAt(stringOffset) - 32) % 64;
             stringOffset++;
 
-            // noAssert === true:
-            // silently apply &0xFF mask, silently drop after byteLength
-            targetBuffer.writeUInt8( total >>> 16, bufferOffset, true );
+            targetBuffer.writeUInt8( total >>> 16, bufferOffset );
             bufferOffset++;
-            targetBuffer.writeUInt8( total >>> 8, bufferOffset, true );
+            if (bufferOffset === targetBuffer.length)
+              break;
+            targetBuffer.writeUInt8( (total >>> 8) & 0xFF, bufferOffset );
             bufferOffset++;
-            targetBuffer.writeUInt8( total, bufferOffset, true );
+            if (bufferOffset === targetBuffer.length)
+              break;
+            targetBuffer.writeUInt8( total & 0xFF, bufferOffset );
             bufferOffset++;
+            if (bufferOffset === targetBuffer.length)
+              break;
          }
          return targetBuffer;
       });
@@ -318,14 +322,18 @@ UUE.prototype.decodeAllFiles = function(text){
             total +=  (lineUUE.charCodeAt(stringOffset) - 32) % 64;
             stringOffset++;
 
-            // noAssert === true:
-            // silently apply &0xFF mask, silently drop after byteLength
-            targetBuffer.writeUInt8( total >>> 16, bufferOffset, true );
+            targetBuffer.writeUInt8( total >>> 16, bufferOffset );
             bufferOffset++;
-            targetBuffer.writeUInt8( total >>> 8, bufferOffset, true );
+            if (bufferOffset === targetBuffer.length)
+              break;
+            targetBuffer.writeUInt8( (total >>> 8) & 0xFF, bufferOffset );
             bufferOffset++;
-            targetBuffer.writeUInt8( total, bufferOffset, true );
+            if (bufferOffset === targetBuffer.length)
+              break;
+            targetBuffer.writeUInt8( total & 0xFF, bufferOffset );
             bufferOffset++;
+            if (bufferOffset === targetBuffer.length)
+              break;
          }
          return targetBuffer;
       });


### PR DESCRIPTION
Using `noAssert` the way it was used here was never supported and
`noAssert' was removed in Node.js 10.x. All input is therefore going
to be validated from now on. This fixes the library by making sure
the input is actually valid when passed to Node.js.

Refs: https://github.com/nodejs/node/pull/18395